### PR TITLE
CHORE - Removal of link URL when content is also displayed

### DIFF
--- a/js/components/application/wrapper/index.jsx
+++ b/js/components/application/wrapper/index.jsx
@@ -11,7 +11,7 @@ import Chat from 'components/chat/index';
 import Settings from 'components/settings';
 import Index from 'components/index';
 import Setup from 'components/setup';
-import Footer from './footer';
+import Footer from '../footer';
 
 import { isStoredConfigValid } from 'actions/identity/config';
 import { app } from 'actions/views';

--- a/js/components/chat/message-list/message-row/message-content/index.jsx
+++ b/js/components/chat/message-list/message-row/message-content/index.jsx
@@ -72,24 +72,23 @@ export default class MessageContent extends Component {
   extraContent() {
     const { firstUrl, isVideo, isImage, tags, hasTags } = this.state;
 
-    if (this.hasExtraContent()) {
-      if (isVideo) {
-        return <VideoContent url={firstUrl} />;
-      } else if (isImage) {
-        return <ImageContent url={firstUrl} />;
-      } else if (hasTags) {
-        return <UrlContent tags={tags} />;
-      }
+    if (isVideo) {
+      return <VideoContent url={firstUrl} />;
+    } else if (isImage) {
+      return <ImageContent url={firstUrl} />;
+    } else if (hasTags) {
+      return <UrlContent tags={tags} />;
     }
   }
 
   render() {
     const { message, className } = this.props;
+    const hasExtraContent = this.hasExtraContent()
 
     return (
       <span className={className}>
-        {!this.hasExtraContent() && message}
-        {this.extraContent()}
+        {!hasExtraContent && message}
+        {hasExtraContent && this.extraContent()}
       </span>
     );
   }

--- a/js/components/chat/message-list/message-row/message-content/index.jsx
+++ b/js/components/chat/message-list/message-row/message-content/index.jsx
@@ -83,7 +83,7 @@ export default class MessageContent extends Component {
 
   render() {
     const { message, className } = this.props;
-    const hasExtraContent = this.hasExtraContent()
+    const hasExtraContent = this.hasExtraContent();
 
     return (
       <span className={className}>

--- a/js/components/chat/message-list/message-row/message-content/index.jsx
+++ b/js/components/chat/message-list/message-row/message-content/index.jsx
@@ -64,28 +64,32 @@ export default class MessageContent extends Component {
       .catch(console.info);
   }
 
-  render() {
-    const { message, className } = this.props;
+  hasExtraContent() {
+    const { firstUrl } = this.state;
+    return !_.isEmpty(firstUrl);
+  }
+
+  extraContent() {
     const { firstUrl, isVideo, isImage, tags, hasTags } = this.state;
 
-    const hasExtraContent = !_.isEmpty(firstUrl);
-
-    let extraContent = '';
-
-    if (hasExtraContent) {
+    if (this.hasExtraContent()) {
       if (isVideo) {
-        extraContent = <VideoContent url={firstUrl} />;
+        return <VideoContent url={firstUrl} />;
       } else if (isImage) {
-        extraContent = <ImageContent url={firstUrl} />;
+        return <ImageContent url={firstUrl} />;
       } else if (hasTags) {
-        extraContent = <UrlContent tags={tags} />;
+        return <UrlContent tags={tags} />;
       }
     }
+  }
+
+  render() {
+    const { message, className } = this.props;
 
     return (
       <span className={className}>
-        {message}
-        {extraContent}
+        {!this.hasExtraContent() && message}
+        {this.extraContent()}
       </span>
     );
   }


### PR DESCRIPTION
## Problem
Link URLS should not be displayed if there is content that will be rendered in that chat message

## Solution
1. Removal of logic within the rendering of the message
2. Addition of two function/methods to handle the link recognition
3. Return now checks for content before displaying (or _not_ displaying) the message